### PR TITLE
Create GitHub action to build on release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [macos-latest, ubuntu-20.04, windows-latest]
+        platform: [ubuntu-20.04, windows-latest]
 
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/test-on-pr.yml
+++ b/.github/workflows/test-on-pr.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [macos-latest, ubuntu-20.04, windows-latest]
+        platform: [ubuntu-20.04, windows-latest]
 
     runs-on: ${{ matrix.platform }}
     steps:


### PR DESCRIPTION
Closes #4 

This automated action will trigger once we push code to the `release` branch. The script is an official GitHub Action [from Tauri themselves](https://github.com/tauri-apps/tauri-action)

There are other scripts there as well, maybe we should add [the test on PR action ](https://github.com/tauri-apps/tauri-action?tab=readme-ov-file#testing-the-build)while we are at it?