### PR TITLE
Add back macOS to the publish action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [ubuntu-20.04, windows-latest]
+        platform: [macos-latest, ubuntu-20.04, windows-latest]
 
     runs-on: ${{ matrix.platform }}
     steps:


### PR DESCRIPTION
We should add macOS back to the build matrix, but only when we release builds. We removed macOS from the build matrix for publish and test on PR because it costs 10 times as much as a Linux action in terms of billable minutes. However, since we won't make releases often it should be fine to include macOS in the publish action