### PR TITLE
CI Caching

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,16 +16,21 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v3
-      - name: setup node
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16
       - name: install Rust stable
         uses: dtolnay/rust-toolchain@stable
+      - name: Rust cache
+        uses: swatinem/rust-cache@v2
+        with:
+          workspaces: './src-tauri -> target'
       - name: install pnpm
         uses: pnpm/action-setup@v2
         with:
           version: 8.x.x
+      - name: Sync node version and setup pnpm cache
+        uses: actions/setup-node@v4
+        with:
+          node-version: 'lts/*'
+          cache: 'pnpm'
       - name: install dependencies (ubuntu only)
         if: matrix.platform == 'ubuntu-20.04'
         run: |

--- a/.github/workflows/test-on-pr.yml
+++ b/.github/workflows/test-on-pr.yml
@@ -17,6 +17,10 @@ jobs:
           node-version: 16
       - name: install Rust stable
         uses: dtolnay/rust-toolchain@stable
+      - name: Rust cache
+        uses: swatinem/rust-cache@v2
+        with:
+          workspaces: './src-tauri -> target'  
       - name: install pnpm
         uses: pnpm/action-setup@v2
         with:

--- a/.github/workflows/test-on-pr.yml
+++ b/.github/workflows/test-on-pr.yml
@@ -17,15 +17,15 @@ jobs:
         uses: swatinem/rust-cache@v2
         with:
           workspaces: './src-tauri -> target'
+      - name: install pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 8.x.x
       - name: Sync node version and setup pnpm cache
         uses: actions/setup-node@v4
         with:
           node-version: 'lts/*'
           cache: 'pnpm'
-      - name: install pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: 8.x.x
       - name: install dependencies (ubuntu only)
         if: matrix.platform == 'ubuntu-20.04'
         run: |

--- a/.github/workflows/test-on-pr.yml
+++ b/.github/workflows/test-on-pr.yml
@@ -11,16 +11,17 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v3
-      - name: setup node
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16
       - name: install Rust stable
         uses: dtolnay/rust-toolchain@stable
       - name: Rust cache
         uses: swatinem/rust-cache@v2
         with:
-          workspaces: './src-tauri -> target'  
+          workspaces: './src-tauri -> target'
+      - name: Sync node version and setup pnpm cache
+        uses: actions/setup-node@v4
+        with:
+          node-version: 'lts/*'
+          cache: 'pnpm'
       - name: install pnpm
         uses: pnpm/action-setup@v2
         with:


### PR DESCRIPTION
Resolves #40 

To see the difference in speed for caching, you can look at some of the commits in this pr:

For Cargo, compare actions for 3bdbbef (before) and f60f773 (after)
For Node/pnpm, compare actions for f60f773 (before) and 62199d2 (after)